### PR TITLE
user fail continue

### DIFF
--- a/sentora-paranoid.sh
+++ b/sentora-paranoid.sh
@@ -143,6 +143,24 @@ ask_user_yn() {
 	done	
 }
 
+# Function that can be called so users have the choice
+ask_user_continue() {
+	END_SCRIPT=""
+	while true; do
+		read -e -p "`echo -e "$COLOR_YLW WARNING: $COLOR_END Step FAIL. Continuing could break your system.
+Would you like to continue anywas? $COLOR_RED (NOT RECOMENDED) $COLOR_END  (y/N): "`" -i "N" END_SCRIPT
+		case $END_SCRIPT in
+			[Yy]* ) echo -e "$COLOR_YLW WARNING: $COLOR_END Continuing even though it could potentially break your system. Press Ctrl+C to exit now (If you changed your mind)"
+					sleep 3
+					break
+					;;
+			[Nn]* ) exit 1;
+					break
+					;;
+		esac
+	done
+}
+
 #====================================================================================
 #--- Display the 'welcome' splash/user warning info..
 clear

--- a/sentora-paranoid.sh
+++ b/sentora-paranoid.sh
@@ -173,7 +173,7 @@ echo "#########################################################################"
 if [ $UID -ne 0 ]; then
 	echo -e "$COLOR_RED Execuion failed: you must be logged in as 'root' to proceed. $COLOR_END"
 	echo "Use command 'sudo -i', then enter root password and then try again."
-	exit 1
+	ask_user_continue
 fi
 
 #====================================================================================
@@ -185,7 +185,7 @@ if [[ "$1" = "status" ]] ; then
 	else
 		echo -e "$COLOR_RED Execuion failed: you must install sentora first. $COLOR_END"
 	fi
-	exit
+	ask_user_continue
 fi
 
 #====================================================================================
@@ -229,7 +229,7 @@ if [[ "$OS" = "CentOs" && ("$VER" = "6" || "$VER" = "7" ) ||
 	fi
 else
     echo -e "$COLOR_RED Sorry, this OS is not supported by sentora-paranoid. $COLOR_END\n" 
-    exit 1
+    ask_user_continue
 fi
 
 #====================================================================================
@@ -263,7 +263,7 @@ if [[ "$OS" = "Ubuntu" ]]; then
 	 UFWstatus=$(ufw status | sed -e "s/Status: //")
 	 if [[ "$UFWstatus" != "inactive" ]] ; then
 		echo -e "$COLOR_RED Execuion failed: you must disable UncomplicatedFirewall (ufw) to proceed. $COLOR_END"
-		exit 1
+		ask_user_continue
 	 fi
 	fi
 	# iptables ipv4 must be installed by default in Ubuntu 14.04
@@ -271,7 +271,7 @@ if [[ "$OS" = "Ubuntu" ]]; then
 	 iptables_version=$(iptables --version | sed -e "s/iptables //")
 	 if [ -z "$iptables_version" ] ; then
 		echo -e "$COLOR_RED Execuion failed: iptables is not preinstalled/running on this system. $COLOR_END"
-		exit 1
+		ask_user_continue
 	 fi
 	fi
 	# iptables ipv6 must be installed by default in Ubuntu 14.04
@@ -279,7 +279,7 @@ if [[ "$OS" = "Ubuntu" ]]; then
 	 ip6tables_version=$(ip6tables --version | sed -e "s/ip6tables //")
 	 if [ -z "$ip6tables_version" ] ; then
 		echo -e "$COLOR_RED Execuion failed: ip6tables is not preinstalled/running on this system. $COLOR_END"
-		exit 1
+		ask_user_continue
 	 fi
 	fi
 	# fail2ban must not be preinstalled
@@ -289,7 +289,7 @@ if [[ "$OS" = "Ubuntu" ]]; then
 			echo "It appears that a failure log scanner is already installed on your server;"
 			echo " This installer is designed to install and configure sentora-paranoid on a clean OS installation with Sentora installed only!"
 			echo -e "\nPlease re-install your OS and sentora $SENTORA_CORE_VERSION before attempting to install senora-paranoid using this script."
-			exit 1
+			ask_user_continue
 		fi
 	fi
 	echo -e "Ok\n"
@@ -327,7 +327,7 @@ if [[ "$REVERT" = "false" ]] ; then
 		EXIST=$(grep "$ADMIN_USR:" /etc/passwd)
 		if [ -z "$EXIST" ] ; then
 			echo -e "$COLOR_RED Execuion failed: administrative user does not exist. $COLOR_END"
-			exit 1
+			ask_user_continue
 		fi
 	fi
 	read -e -p "Please enter administrative group name: " -i "$ADMIN_GRP" ADMIN_GRP
@@ -337,7 +337,7 @@ if [[ "$REVERT" = "false" ]] ; then
 		EXIST=$(grep "$ADMIN_GRP:" /etc/group)
 		if [ -z "$EXIST" ] ; then
 			echo -e "$COLOR_RED Execuion failed: administrative group does not exist. $COLOR_END"
-			exit 1
+			ask_user_continue
 		fi
 	fi
 	echo -e "Using:$COLOR_GRN $ADMIN_USR : $ADMIN_GRP $COLOR_END as the administrative username:groupame"


### PR DESCRIPTION
When there is an error, like fail2ban being preinstalled, the script gives an error and rather abruptly exits. This will cause the user to still be warned against the issue, however puts the user in control whether or not to actually exit.
